### PR TITLE
Add Authbox support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 banned_numbers.js
 mixpanel_config.js
+authbox_config.js
 keys.json
 
 *.swp

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     }
   , "dependencies": {
       "express": "~3.5.1"
+      , "authbox": "^0.9.2"
       , "jade": "~0.14.2"
       , "nodemailer": "~0.6.1"
       , "redis-url": "~0.2.0"


### PR DESCRIPTION
Adds anti-spam and abuse support by Authbox. For now this just logs data so we can prepare blacklists for you offline. Once that looks good I can send an additional PR that can turn on verdicts in real time so you don't have to manage blacklists.