### PR TITLE
Add Ting as a Provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Canadian and international support may not be complete.  Refer to the list of su
 
  *  Some carriers may deliver text messages from "txt@textbelt.com"
 
- *  Supported U.S. carriers: Alltel, Ameritech, AT&T Wireless, Boost, CellularOne, Cingular, Edge Wireless, Sprint PCS, Telus Mobility, T-Mobile, Metro PCS, Nextel, O2, Orange, Qwest, Rogers Wireless, US Cellular, Verizon, Virgin Mobile.
+ *  Supported U.S. carriers: Alltel, Ameritech, AT&T Wireless, Boost, CellularOne, Cingular, Edge Wireless, Sprint PCS, Telus Mobility, T-Mobile, Metro PCS, Nextel, O2, Orange, Qwest, Rogers Wireless, Ting, US Cellular, Verizon, Virgin Mobile.
 
  *  Supported U.S. and Canadian carriers (/canada):  3 River Wireless, ACS Wireless, AT&T, Alltel, BPL Mobile, Bell Canada, Bell Mobility, Bell Mobility (Canada), Blue Sky Frog, Bluegrass Cellular, Boost Mobile, Carolina West Wireless, Cellular One, Cellular South, Centennial Wireless, CenturyTel, Cingular (Now AT&T), Clearnet, Comcast, Corr Wireless Communications, Dobson, Edge Wireless, Fido, Golden Telecom, Helio, Houston Cellular, Idea Cellular, Illinois Valley Cellular, Inland Cellular Telephone, MCI, MTS, Metro PCS, Metrocall, Metrocall 2-way, Microcell, Midwest Wireless, Mobilcomm, Nextel, OnlineBeep, PCS One, President's Choice, Public Service Cellular, Qwest, Rogers AT&T Wireless, Rogers Canada, Satellink, Solo Mobile, Southwestern Bell, Sprint, Sumcom, Surewest Communicaitons, T-Mobile, Telus, Tracfone, Triton, US Cellular, US West, Unicel, Verizon, Virgin Mobile, Virgin Mobile Canada, West Central Wireless, Western Wireless
 

--- a/lib/providers.js
+++ b/lib/providers.js
@@ -3,6 +3,7 @@ module.exports = {
   us: [
     '%s@email.uscc.net',
     '%s@message.alltel.com',
+    '%s@message.ting.com',
     '%s@messaging.sprintpcs.com',
     '%s@mobile.celloneusa.com',
     '%s@msg.telus.com',


### PR DESCRIPTION
Confirmation from Ting agent that this is supported:
https://help.ting.com/hc/communities/public/questions/203771568-Can-you-send-a-text-message-to-a-phone-number-via-the-internet-email-