### PR TITLE
Added carrier support. typpo/textbelt#56

### DIFF
--- a/lib/carriers.js
+++ b/lib/carriers.js
@@ -1,0 +1,398 @@
+module.exports = {
+
+  uscellular: [
+    '%s@email.uscc.net',
+  ],
+  alltel: [
+    '%s@message.alltel.com',
+  ],
+  ting: [
+    '%s@message.ting.com',
+  ],
+  sprint: [
+    '%s@messaging.sprintpcs.com',
+  ],
+  cellone: [
+    '%s@mobile.celloneusa.com',
+  ],
+  telus: [
+    '%s@msg.telus.com',
+  ],
+  alaskacommunications: [
+    '%s@paging.acswireless.com',
+  ],
+  rogers: [
+    '%s@pcs.rogers.com',
+  ],
+  cricket: [
+    '%s@sms.mycricket.com',
+  ],
+  tmobile: [
+    '%s@tmomail.net',
+  ],
+  att: [
+    '%s@txt.att.net',
+  ],
+  westernwireless: [
+    '%s@cellularonewest.com',
+  ],
+  windmobile: [
+    '%s@txt.windmobile.ca',
+  ],
+  verizon: [
+    '%s@vtext.com',
+  ],
+  republic: [
+    '%s@text.republicwireless.com'
+  ],
+  /*edgewireless: [
+   //'%s@sms.edgewireless.com',  // slow
+  ],*/
+  bluskyfrog: [
+    '%s@blueskyfrog.com',
+  ],
+  loopmobile: [
+    '%s@bplmobile.com',
+  ],
+  clearlydigital: [
+    '%s@clearlydigital.com',
+  ],
+  comcast: [
+    '%s@comcastpcs.textmsg.com',
+  ],
+  corrwireless: [
+    '%s@corrwireless.net',
+  ],
+  cellularsouth: [
+    '%s@csouth1.com',
+  ],
+  centennialwireless: [
+    '%s@cwemail.com',
+  ],
+  carolinawestwireless: [
+    '%s@cwwsms.com',
+  ],
+  southwesternbell: [
+    '%s@email.swbw.com',
+  ],
+  fido: [
+    '%s@fido.ca',
+  ],
+  ideacellular: [
+    '%s@ideacellular.net',
+  ],
+  indianapaging: [
+    '%s@inlandlink.com',
+  ],
+  illinoisvalleycellular: [
+    '%s@ivctext.com',
+  ],
+  alltel: [
+    '%s@message.alltel.com',
+  ],
+  centurytel: [
+    '%s@messaging.centurytel.net',
+  ],
+  dobson: [
+    '%s@mobile.dobson.net',
+  ],
+  surewestcommunications: [
+    '%s@mobile.surewest.com',
+  ],
+  mobilcomm: [
+    '%s@mobilecomm.net',
+  ],
+  clearnet: [
+    '%s@msg.clearnet.com',
+  ],
+  koodomobile: [
+    '%s@msg.koodomobile.com',
+  ],
+  metrocall2way: [
+    '%s@my2way.com',
+  ],
+  boostmobile: [
+    '%s@myboostmobile.com',
+  ],
+  onlinebeep: [
+    '%s@onlinebeep.net',
+  ],
+  metrocall: [
+    '%s@page.metrocall.com',
+  ],
+  mci: [
+    '%s@pagemci.com',
+  ],
+  ameritechpaging: [
+    '%s@paging.acswireless.com',
+  ],
+  pcsone: [
+    '%s@pcsone.net',
+  ],
+  qwest: [
+    '%s@qwestmp.com',
+  ],
+  satellink: [
+    '%s@satellink.net',
+  ],
+  threeriverwireless: [
+    '%s@sms.3rivers.net',
+  ],
+  bluegrasscellular: [ 
+    '%s@sms.bluecell.com',
+  ],
+  edgewireless: [
+    '%s@sms.edgewireless.com',
+  ],
+  goldentelecom: [
+    '%s@sms.goldentele.com',
+  ],
+  publicservicecellular: [
+    '%s@sms.pscel.com',
+  ],
+  westcentralwireless: [
+    '%s@sms.wcc.net',
+  ],
+  houstoncellular: [
+    '%s@text.houstoncellular.net',
+  ],
+  mts: [
+    '%s@text.mtsmobility.com',
+  ],
+  suncom: [
+    '%s@tms.suncom.com',
+  ],
+  bellmobilitycanada: [
+    '%s@txt.bell.ca',
+  ],
+  northerntelmobility: [
+    '%s@txt.northerntelmobility.com',
+  ],
+  uswest: [
+    '%s@uswestdatamail.com',
+  ],
+  unicel: [
+    '%s@utext.com',
+  ],
+  virginmobilecanada: [
+    '%s@vmobile.ca',
+  ],
+  virginmobile: [
+    '%s@vmobl.com',
+  ],
+  airtelchennai: [
+    '%s@airtelchennai.com',
+  ],
+  kolkataairtel: [
+    '%s@airtelkol.com',
+  ],
+  delhiairtel: [
+    '%s@airtelmail.com',
+  ],
+  tsrwireless: [
+    '%s@alphame.com',
+  ],
+  swisscom: [
+    '%s@bluewin.ch',
+  ],
+  mumbaibplmobile: [
+    '%s@bplmobile.com',
+  ],
+  vodafonejapan: [
+    '%s@c.vodafone.ne.jp',
+    '%s@h.vodafone.ne.jp',
+    '%s@t.vodafone.ne.jp',
+  ],
+  gujaratcelforce: [
+    '%s@celforce.com',
+  ],
+  movistar: [
+    '%s@correo.movistar.net',
+  ],
+  delhihutch: [
+    '%s@delhi.hutch.co.in',
+  ],
+  digitextjamacian: [
+    '%s@digitextjm.com',
+  ],
+  jsmtelepage: [
+    '%s@e-page.net',
+  ],
+  escotel: [
+    '%s@escotelmobile.com',
+  ],
+  surewestcommunications: [
+    '%s@freesurf.ch',
+  ],
+  teliadenmark: [
+    '%s@gsm1800.telia.dk',
+  ],
+  ideacellular: [
+    '%s@ideacellular.net',
+  ],
+  itelcel: [
+    '%s@itelcel.com',
+  ],
+  mobileone: [
+    '%s@m1.com.sg',
+  ],
+  m1bermuda: [
+    '%s@ml.bm',
+  ],
+  o2mmail: [
+    '%s@mmail.co.uk',
+  ],
+  telenor: [
+    '%s@mobilpost.no',
+  ],
+  mobistarbelgium: [
+    '%s@mobistar.be',
+  ],
+  mobtelsrbija: [
+    '%s@mobtel.co.yu',
+  ],
+  telefonicamovistar: [
+    '%s@movistar.net',
+  ],
+  nextelmexico: [
+    '%s@msgnextel.com.mx',
+  ],
+  globalstar: [
+    '%s@msg.globalstarusa.com',
+  ],
+  iridiumsatellitecommunications: [
+    '%s@msg.iridium.com',
+  ],
+  oskar: [
+    '%s@mujoskar.cz',
+  ],
+  meteor: [
+    '%s@mymeteor.ie',
+  ],
+  smarttelecom: [
+    '%s@mysmart.mymobile.ph',
+  ],
+  sunrisemobile: [
+    '%s@mysunrise.ch',
+    '%s@swmsg.com',
+  ],
+  o2: [
+    '%s@o2.co.uk',
+    '%s@o2imail.co.uk',
+  ],
+  oneconnectaustria: [
+    '%s@onemail.at',
+  ],
+  onlinebeep: [
+    '%s@onlinebeep.net',
+  ],
+  optusmobile: [
+    '%s@optusmobile.com.au',
+  ],
+  /*orange: [
+    //'%s@orange.net',
+    //'%s@orangemail.co.in',
+  ],*/
+  mobilfone: [
+    '%s@page.mobilfone.com',
+  ],
+  southernlinc: [
+    '%s@page.southernlinc.com',
+  ],
+  teletouch: [
+    '%s@pageme.teletouch.com',
+  ],
+  vessotel: [
+    '%s@pager.irkutsk.ru',
+  ],
+  ntelos: [
+    '%s@pcs.ntelos.com',
+  ],
+  rek2: [
+    '%s@rek2.com.mx',
+  ],
+  chennairpgcellular: [
+    '%s@rpgmail.net',
+  ],
+  safaricom: [
+    '%s@safaricomsms.com',
+  ],
+  satelindogsm: [
+    '%s@satelindogsm.com',
+  ],
+  scs900: [
+    '%s@scs-900.ru',
+  ],
+  sfrfrance: [
+    '%s@sfr.fr',
+  ],
+  mobiteltanzania: [
+    '%s@sms.co.tz',
+  ],
+  comviq: [
+    '%s@sms.comviq.se',
+  ],
+  emt: [
+    '%s@sms.emt.ee',
+  ],
+  geldentelecom: [
+    '%s@sms.goldentele.com',
+  ],
+  pandtluxembourg: [
+    '%s@sms.luxgsm.lu',
+  ],
+  netcom: [
+    '%s@sms.netcom.no',
+  ],
+  /*orangenl: [
+    //'%s@sms.orange.nl',
+  ],*/
+  primtel: [
+    '%s@sms.primtel.ru',
+  ],
+  tmobileaustria: [
+    '%s@sms.t-mobile.at',
+  ],
+  tele2lativa: [
+    '%s@sms.tele2.lv',
+  ],
+  umc: [
+    '%s@sms.umc.com.ua',
+  ],
+  uraltel: [
+    '%s@sms.uraltel.ru',
+  ],
+  vodafoneitaly: [
+    '%s@sms.vodafone.it',
+  ],
+  lmt: [
+    '%s@smsmail.lmt.lv',
+  ],
+  tmobilegermany: [
+    '%s@t-d1-sms.de',
+  ],
+  dttmobile: [
+    '%s@t-mobile-sms.de',
+  ],
+  tmobileuk: [
+    '%s@t-mobile.uk.net',
+  ],
+  simplefreedom: [
+    '%s@text.simplefreedom.net',
+  ],
+  tim: [
+    '%s@timnet.com',
+  ],
+  vodafone: [
+    '%s@vodafone.net',
+  ],
+  wyndtell: [
+    '%s@wyndtell.com',
+  ],
+  /*personalcommunication: [
+    //'sms@pcom.ru (put the number in the subject line)',
+  ],*/
+  /*jsmtelepage: [
+    //'pinnumber@jsmtel.com',
+  ],*/
+};

--- a/lib/text.js
+++ b/lib/text.js
@@ -1,5 +1,6 @@
 var providers = require('./providers.js')
   , _ = require('underscore')
+  , carriers = require('./carriers.js')
   , exec = require('child_process').exec
   , spawn = require('child_process').spawn;
 var StringDecoder = require('string_decoder').StringDecoder;
@@ -46,12 +47,17 @@ function debug(enable) {
       region - region to use (defaults to US)
       cb - function(err), provides err messages
 */
-function sendText(phone, message, region, cb) {
+function sendText(phone, message, carrier, region, cb) {
   output('txting phone', phone, ':', message);
 
   region = region || 'us';
 
-  var providers_list = providers[region];
+  var providers_list;
+  if (carrier == null) {
+    providers_list = providers[region];
+  } else {
+    providers_list = carriers[carrier];
+  }
 
   var done = _.after(providers_list.length, function() {
     cb(false);


### PR DESCRIPTION
Added a carriers.js file which holds the association of carriers to email addresses. This file was created from the providers.js file.

You can POST to /text getcarriers=1 or getcarriers=true to get the list of supported carriers.

You can POST carrier=<xyz> to perform the lookup and only email the corresponding email address(es) instead of all of them. If carrier is null the previous behavior of emailing everyone takes effect so as to not break compatibility.

There is also some error handling for when a user specifies a non existent carrier.

Feedback welcome.

typpo/textbelt#56

