### PR TITLE
Add Nex-Tech Wireless as a provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Canadian and international support may not be complete.  Refer to the list of su
 
  *  Some carriers may deliver text messages from "txt@textbelt.com"
 
- *  Supported U.S. carriers: Alltel, Ameritech, AT&T Wireless, Boost, CellularOne, Cingular, Edge Wireless, Sprint PCS, Telus Mobility, T-Mobile, Metro PCS, Nextel, O2, Orange, Qwest, Rogers Wireless, Ting, US Cellular, Verizon, Virgin Mobile.
+ *  Supported U.S. carriers: Alltel, Ameritech, AT&T Wireless, Boost, CellularOne, Cingular, Edge Wireless, Nex-Tech Wireless, Sprint PCS, Telus Mobility, T-Mobile, Metro PCS, Nextel, O2, Orange, Qwest, Rogers Wireless, Ting, US Cellular, Verizon, Virgin Mobile.
 
  *  Supported U.S. and Canadian carriers (/canada):  3 River Wireless, ACS Wireless, AT&T, Alltel, BPL Mobile, Bell Canada, Bell Mobility, Bell Mobility (Canada), Blue Sky Frog, Bluegrass Cellular, Boost Mobile, Carolina West Wireless, Cellular One, Cellular South, Centennial Wireless, CenturyTel, Cingular (Now AT&T), Clearnet, Comcast, Corr Wireless Communications, Dobson, Edge Wireless, Fido, Golden Telecom, Helio, Houston Cellular, Idea Cellular, Illinois Valley Cellular, Inland Cellular Telephone, MCI, MTS, Metro PCS, Metrocall, Metrocall 2-way, Microcell, Midwest Wireless, Mobilcomm, Nextel, OnlineBeep, PCS One, President's Choice, Public Service Cellular, Qwest, Republic Wireless, Rogers AT&T Wireless, Rogers Canada, Satellink, Solo Mobile, Southwestern Bell, Sprint, Sumcom, Surewest Communicaitons, T-Mobile, Telus, Tracfone, Triton, US Cellular, US West, Unicel, Verizon, Virgin Mobile, Virgin Mobile Canada, West Central Wireless, Western Wireless
 

--- a/lib/carriers.js
+++ b/lib/carriers.js
@@ -27,6 +27,9 @@ module.exports = {
   cricket: [
     '%s@sms.mycricket.com',
   ],
+  nex-tech: [
+    '%s@sms.ntwls.net',
+  ],
   tmobile: [
     '%s@tmomail.net',
   ],

--- a/lib/providers.js
+++ b/lib/providers.js
@@ -11,6 +11,7 @@ module.exports = {
     '%s@pcs.rogers.com',
     '%s@qwestmp.com',
     '%s@sms.mycricket.com',
+    '%s@sms.ntwls.net',
     '%s@tmomail.net',
     '%s@txt.att.net',
     '%s@txt.windmobile.ca',


### PR DESCRIPTION
Nex-Tech Wireless is working with a local company to provide messaging alerts over their network using the textbelt.com platform which requires the addition of their email2sms gateway to your provider list.