### PR TITLE
Removed Ting as Sprint Duplicate

### DIFF
--- a/lib/carriers.js
+++ b/lib/carriers.js
@@ -6,9 +6,9 @@ module.exports = {
   alltel: [
     '%s@message.alltel.com',
   ],
-  ting: [
-    '%s@message.ting.com',
-  ],
+  /*ting: [
+    '%s@message.ting.com', // Duplicate of Sprint
+  ],*/
   sprint: [
     '%s@messaging.sprintpcs.com',
   ],

--- a/lib/providers.js
+++ b/lib/providers.js
@@ -3,7 +3,6 @@ module.exports = {
   us: [
     '%s@email.uscc.net',
     '%s@message.alltel.com',
-    '%s@message.ting.com',
     '%s@messaging.sprintpcs.com',
     '%s@mobile.celloneusa.com',
     '%s@msg.telus.com',
@@ -17,6 +16,7 @@ module.exports = {
     '%s@vtext.com',
     '%s@text.republicwireless.com'
 
+    //'%s@message.ting.com', // Duplicate of Sprint
     //'%s@sms.edgewireless.com',  // slow
   ],
 


### PR DESCRIPTION
Ting uses the Sprint network, so any messages sent to a Sprint number will be delivered twice: once through `number@messaging.sprintpcs.com` and once through `number@messages.ting.com`.