### PR TITLE
Lint lib/

### DIFF
--- a/lib/carriers.js
+++ b/lib/carriers.js
@@ -221,14 +221,11 @@ module.exports = {
   escotel: [
     '%s@escotelmobile.com',
   ],
-  surewestcommunications: [
+  sunrisecommunications: [
     '%s@freesurf.ch',
   ],
   teliadenmark: [
     '%s@gsm1800.telia.dk',
-  ],
-  ideacellular: [
-    '%s@ideacellular.net',
   ],
   itelcel: [
     '%s@itelcel.com',
@@ -282,9 +279,6 @@ module.exports = {
   ],
   oneconnectaustria: [
     '%s@onemail.at',
-  ],
-  onlinebeep: [
-    '%s@onlinebeep.net',
   ],
   optusmobile: [
     '%s@optusmobile.com.au',

--- a/lib/text.js
+++ b/lib/text.js
@@ -1,9 +1,7 @@
-var providers = require('./providers.js')
-  , _ = require('underscore')
-  , carriers = require('./carriers.js')
-  , exec = require('child_process').exec
-  , spawn = require('child_process').spawn;
-var StringDecoder = require('string_decoder').StringDecoder;
+var providers = require('./providers.js'),
+    carriers = require('./carriers.js'),
+    spawn = require('child_process').spawn,
+    StringDecoder = require('string_decoder').StringDecoder;
 
 var debugEnabled = false;
 
@@ -44,6 +42,7 @@ function debug(enable) {
     Params:
       phone - phone number to text
       message - message to send
+      carrier - carrier to use (may be null)
       region - region to use (defaults to US)
       cb - function(err), provides err messages
 */
@@ -53,10 +52,10 @@ function sendText(phone, message, carrier, region, cb) {
   region = region || 'us';
 
   var providers_list;
-  if (carrier == null) {
-    providers_list = providers[region];
-  } else {
+  if (carrier !== null) {
     providers_list = carriers[carrier];
+  } else {
+    providers_list = providers[region];
   }
 
   var emails = providers_list.map(function(provider) {
@@ -79,7 +78,7 @@ function sendText(phone, message, carrier, region, cb) {
   child.on('exit', function(code, signal) {
     cb(false);
   });
-  console.log(message);
+  output(message);
   child.stdin.write(message);
   child.stdin.end();
 }


### PR DESCRIPTION
The carriers file contains duplicate keys. They have been resolved:
- exact duplicate of ideacellular deleted
- exact duplicate of onlinebeep deleted
- one duplicate of surewestcommunications (%s@freesurf.ch) renamed to sunrisecommunications as www.freesurf.ch redirects to sunrise.ch

Unused variables were defined in the library. They have been resolved:
- reference to the `underscore` module deleted
- reference to the `exec` function of the `child_process` module deleted

The carrier argument in text.send was not documented in the library code. That line of documentation has been added.

The carrier argument in text.send was not being checked as strictly equal to null. The triple-equals operator has now been applied to the comparison.

The requires had bad line breakings before commas. The commas have all been moved to ends of lines instead.

On an unrelated not to lint, the console.log call in the text library has been switched out with an output call to obey the debug setting.