### PR TITLE
Update readme, fromAddress is to be set from config.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Textbelt also depends on a local installation of `mutt`, the email client (http:
 
 By default, the server listens on port 9090 and is configured to accept traffic from a reverse proxy or load balancer such as nginx.  To enable accurate IP rate limiting, the reverse proxy should be configured to set the `X-Real-IP` header.
 
-Don't forget to set `fromAddress` in `lib/text.js` to the email address you want to send from.
+Don't forget to set `fromAddress` in `lib/config.js` to the email address you want to send from.
 
 ### Canadian and International endpoints
 


### PR DESCRIPTION
Before this file stated to modify the from address in lib/text.js when in fact the address is configured in lib/config.js and then the configuration variable is imported into the text.js file.