### PR TITLE
remove separate cricket entry

### DIFF
--- a/lib/providers.js
+++ b/lib/providers.js
@@ -9,7 +9,6 @@ module.exports = {
     '%s@paging.acswireless.com',
     '%s@pcs.rogers.com',
     '%s@qwestmp.com',
-    '%s@sms.mycricket.com',
     '%s@sms.ntwls.net',
     '%s@tmomail.net',
     '%s@txt.att.net',


### PR DESCRIPTION
Cricket switched over to AT&T's servers, and now uses txt.att.net instead of its own entry.