### PR TITLE
Converted to NodeMailer, and updated Cricket email (fixes #133)

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,15 @@ Sample failure:
 
 Though this repository contains an express server so you may run your own
 instance of the web app, you may also use it to send text messages in your
-project. The only requirement is unix/posix `sendmail`, used to forward the message.
+project. 
+
+#### Configuration:
+This project uses [`nodemailer`](https://www.npmjs.com/package/nodemailer) for sending emails. Set up `lib/config.js` with the following: 
+
+- **`transport`** should be a Nodemailer transport [documented here](https://nodemailer.com/plugins/create/#transports)
+- **`mailOptions`** fields should include at least include the `from` field, but you can include any of the fields [documented here](https://nodemailer.com/message/). 
+
+A sample transport with SMTP sending is included.
 
 For example, to send a text using the default settings:
 

--- a/lib/carriers.js
+++ b/lib/carriers.js
@@ -22,7 +22,7 @@ module.exports = {
     '%s@pcs.rogers.com',
   ],
   cricket: [
-    '%s@sms.mycricket.com',
+    '%s@mms.cricketwireless.net',
   ],
   'nex-tech': [
     '%s@sms.ntwls.net',

--- a/lib/config.js
+++ b/lib/config.js
@@ -1,4 +1,18 @@
 module.exports = {
-  fromAddress: 'foo@bar.com',
+  transport: {
+    host: "smtp.example.com",
+    port: 587,
+    auth: {
+      user: "user@example.com",
+      pass: "example password 1"
+    },
+    secureConnection: 'false',
+    tls: {
+      ciphers: 'SSLv3'
+    }
+  },
+  mailOptions: {
+    from: '"Jane Doe" <jane.doe@example.com>'
+  },
   debugEnabled: false,
 };

--- a/lib/text.js
+++ b/lib/text.js
@@ -1,9 +1,7 @@
-const { StringDecoder } = require('string_decoder');
-const { spawn } = require('child_process');
+const nodemailer = require("nodemailer");
 
 const carriers = require('./carriers.js');
 const providers = require('./providers.js');
-
 
 let config = require('./config.js');
 
@@ -30,7 +28,7 @@ function output(...args) {
       message - message to send
       carrier - carrier to use (may be null)
       region - region to use (defaults to US)
-      cb - function(err), provides err messages
+      cb - function(err, info), NodeMailer callback
 */
 function sendText(phone, message, carrier, region, cb) {
   output('txting phone', phone, ':', message);
@@ -43,26 +41,18 @@ function sendText(phone, message, carrier, region, cb) {
   }
 
   const emails = providersList.map(provider => provider.replace('%s', phone)).join(',');
-  const args = ['-s', 'txt', '-e', `set from=${config.fromAddress}`,
-    '-e', 'set use_from=yes', '-e', 'set envelope_from=yes', '-b', emails];
-  const child = spawn('mutt', args);
-  const decoder = new StringDecoder('utf8');
-  child.stdout.on('data', (data) => {
-    output(decoder.write(data));
-  });
-  child.stderr.on('data', (data) => {
-    output(decoder.write(data));
-  });
-  child.on('error', (data) => {
-    output('mutt failed', { email: emails, data: decoder.write(data) });
-    cb(false);
-  });
-  child.on('exit', () => {
-    cb(false);
-  });
-  output(message);
-  child.stdin.write(message);
-  child.stdin.end();
+
+  let transporter = nodemailer.createTransport(config.transport);
+
+  let mailOptions = {
+    to: emails,
+    subject: null,
+    text: message,
+    html: message,
+    ...config.mailOptions
+  };
+
+  transporter.sendMail(mailOptions, cb);
 }
 
 //----------------------------------------------------------------

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
     "url": "git@github.com:typpo/textbelt.git"
   },
   "dependencies": {
-    "express": ">=4.0.0"
+    "express": ">=4.0.0",
+    "nodemailer": "^5.1.1"
   },
   "devDependencies": {
     "eslint": "^5.9.0",


### PR DESCRIPTION
textbelt now uses nodemailer! The email for Cricket Wireless was also updated, so I changed that as well. 

I updated the README, let me know if anything seems off. :)

I hope I managed to get rid of mutt (#133) -- if this makes anything else obsolete, we should probably get rid of that too. 