### PR TITLE
Seperate emails

### DIFF
--- a/lib/text.js
+++ b/lib/text.js
@@ -40,19 +40,33 @@ function sendText(phone, message, carrier, region, cb) {
     providersList = providers[region || 'us'];
   }
 
-  const emails = providersList.map(provider => provider.replace('%s', phone)).join(',');
-
   const transporter = nodemailer.createTransport(config.transport);
 
-  const mailOptions = {
-    to: emails,
-    subject: null,
-    text: message,
-    html: message,
-    ...config.mailOptions,
-  };
+  let p = Promise.all(providersList.map(provider => {
+    const to = provider.replace('%s', phone);
 
-  transporter.sendMail(mailOptions, cb);
+    const mailOptions = {
+      to,
+      subject: null,
+      text: message,
+      html: message,
+      ...config.mailOptions,
+    };
+
+    return new Promise((resolve, reject) => {
+      transporter.sendMail(mailOptions, function(err, info) {
+        if (err) return reject(err);
+        resolve(info);
+      });
+    });
+  }));
+
+  if (cb) {
+    p.then(info => cb(null, info[0]), err => cb(err));
+    return
+  }
+
+  return p;
 }
 
 //----------------------------------------------------------------
@@ -62,7 +76,7 @@ function sendText(phone, message, carrier, region, cb) {
     used to override the defaults
 
     Params:
-      obj - object of config properties to be overriden
+      obj - object of config properties to be overridden
 */
 function setConfig(obj) {
   config = Object.assign(config, obj);

--- a/lib/text.js
+++ b/lib/text.js
@@ -42,7 +42,7 @@ function sendText(phone, message, carrier, region, cb) {
 
   const transporter = nodemailer.createTransport(config.transport);
 
-  let p = Promise.all(providersList.map(provider => {
+  const p = Promise.all(providersList.map((provider) => {
     const to = provider.replace('%s', phone);
 
     const mailOptions = {
@@ -53,17 +53,22 @@ function sendText(phone, message, carrier, region, cb) {
       ...config.mailOptions,
     };
 
-    return new Promise((resolve, reject) => {
-      transporter.sendMail(mailOptions, function(err, info) {
-        if (err) return reject(err);
-        resolve(info);
-      });
-    });
+    return new Promise((resolve, reject) => transporter.sendMail(mailOptions, (err, info) => {
+      if (err) return reject(err);
+      return resolve(info);
+    }));
   }));
 
+  // If the callback is provided, simulate the first message as the old-style
+  // callback format, then return the full promise.
   if (cb) {
-    p.then(info => cb(null, info[0]), err => cb(err));
-    return
+    return p.then((info) => {
+      cb(null, info[0]);
+      return info;
+    }, (err) => {
+      cb(err);
+      return err;
+    });
   }
 
   return p;


### PR DESCRIPTION
Addresses #138 

Sends SMS emails as individual emails instead of sending a single email with multiple recipients. This fixes the messaging for T-mobile.

This also adds a promise-based alternative to the API. 