### PR TITLE
Change windmobile to freedommobile

### DIFF
--- a/lib/carriers.js
+++ b/lib/carriers.js
@@ -36,8 +36,8 @@ module.exports = {
   westernwireless: [
     '%s@cellularonewest.com',
   ],
-  windmobile: [
-    '%s@txt.windmobile.ca',
+  freedommobile: [
+    '%s@txt.freedommobile.ca',
   ],
   verizon: [
     '%s@vtext.com',


### PR DESCRIPTION
Wind Mobile was rebranded to Freedom Mobile in 2016.