### PR TITLE
Add another go client

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Canadian and international support may not be complete.  Refer to the list of su
 ### Textbelt Clients
 
   * ruby - [djds23/textbelt-gem](https://github.com/djds23/textbelt-gem)
-  * go - [dietsche/textbelt](https://github.com/dietsche/textbelt)
+  * go - [dietsche/textbelt](https://github.com/dietsche/textbelt), [lateralusd/textbelt](https://github.com/lateralusd/textbelt)
   * python - [ksdme/py-textbelt](https://github.com/ksdme/py-textbelt)
   * node.js - [minond/textbelt](https://github.com/minond/textbelt), [ajay-gandhi/textbelt](https://github.com/ajay-gandhi/textbelt), [soondobu/mtextbelt](https://github.com/soondobu/mtextbelt)
   * php - [ctrlaltdylan/courier](https://github.com/ctrlaltdylan/courier), [securingsincity/phpsms](https://github.com/securingsincity/phpsms)


### PR DESCRIPTION
Hello, I have created another go library for textbelt, it supports more features like:

* Quota
* Generating OTP(custom and usual one)
* Verify OTP
* Checking status of the message
* Sending the message

If you would like to see any more changes, let me know.

Cheers